### PR TITLE
fix #3: changed permissions to write for contents in GA

### DIFF
--- a/.github/workflows/deploy_hugo_website.yml
+++ b/.github/workflows/deploy_hugo_website.yml
@@ -8,7 +8,7 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: read
+    contents: write 
     pages: write
     id-token: write
 


### PR DESCRIPTION
Fix permissions in Github Actions so that the deploy may continue normally.

Close #3 